### PR TITLE
Route release.yml through metanorma/support wrapper

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,6 +26,6 @@ jobs:
     steps:
       - id: automerge
         name: automerge
-        uses: pascalgn/automerge-action@v0.16.4
+        uses: pascalgn/automerge-action@v0.16
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,16 @@ on:
   repository_dispatch:
     types: [ do-release ]
 
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
 jobs:
   release:
-    uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
+    uses: metanorma/support/.github/workflows/release.yml@main
     with:
       next_version: ${{ github.event.inputs.next_version }}
     secrets:
       rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
-      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
 


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/292
Full plan: https://github.com/metanorma/cimas/blob/main/plans/cimas-revival-and-release-workflow-realignment.md

Routes this repo's `release.yml` through the new `metanorma/support` wrapper, bringing it into alignment with the `<org>/support` pattern already used by `relaton/support`, `fontist/support`, and `lutaml/support`. The `pat_token` reference is dropped (the wrapper does not forward it, matching the convention used by the other org-level support wrappers).

Generated by the cimas-sync wave; canary-verified end-to-end on `metanorma-taste` 1.0.8 (published 2026-06-16 12:54 UTC via the new wrapper path).

🤖
